### PR TITLE
Add patch to fix buffer delay on amfenc

### DIFF
--- a/build/0002-disable-hwbuffers.patch
+++ b/build/0002-disable-hwbuffers.patch
@@ -1,0 +1,24 @@
+diff --git a/libavcodec/amfenc.c b/libavcodec/amfenc.c
+index fb23ed738c..c452a0fd5b 100644
+--- a/libavcodec/amfenc.c
++++ b/libavcodec/amfenc.c
+@@ -219,7 +219,7 @@ static int amf_init_context(AVCodecContext *avctx)
+     av_unused int ret;
+ 
+     ctx->hwsurfaces_in_queue = 0;
+-    ctx->hwsurfaces_in_queue_max = 16;
++    ctx->hwsurfaces_in_queue_max = avctx->max_b_frames > 0 ? 16 : 0; // avoid buffering frames if no B frames are in use
+ 
+     // configure AMF logger
+     // the return of these functions indicates old state and do not affect behaviour
+@@ -769,7 +769,9 @@ int ff_amf_receive_packet(AVCodecContext *avctx, AVPacket *avpkt)
+             }
+         } else if (ctx->delayed_surface != NULL || ctx->delayed_drain || (ctx->eof && res_query != AMF_EOF) || (ctx->hwsurfaces_in_queue >= ctx->hwsurfaces_in_queue_max)) {
+             block_and_wait = 1;
+-            av_usleep(1000); // wait and poll again
++            if (avctx->max_b_frames > 0) {
++                av_usleep(1000); // wait and poll again
++            }
+         }
+     } while (block_and_wait);
+ 

--- a/build/ffmpeg_extra.sh
+++ b/build/ffmpeg_extra.sh
@@ -1,6 +1,7 @@
 _pre_configure(){
     #
     # Apply a patch from ffmpeg's patchwork site.
-    do_patch "https://raw.githubusercontent.com/TheElixZammuto/sunshine-prebuilt/master/build/0001-patch-idr-on-amf.patch" patch
+    do_patch "https://raw.githubusercontent.com/LizardByte/ffmpeg-prebuilt/master/build/0001-patch-idr-on-amf.patch" patch
+    do_patch "https://raw.githubusercontent.com/LizardByte/ffmpeg-prebuilt/master/build/0002-disable-hwbuffers.patch" patch
     #
 }


### PR DESCRIPTION
## Description
* Add patch that eliminates hw buffer and hardcoded sleep in amfenc when avctx->max_b_frames is 0
* Update new and old patches to point to correct repository location

This completely eliminates the desktop delay/slowdown issue with the amfenc encoder.

N.B. Due to the patch being hardcoded to fetch the raw file from the repository's master branch, nightly needs to be merged into master before a build can succeed with the new patch.

### Issues Fixed or Closed
Closes: https://github.com/LizardByte/Sunshine/issues/122, https://github.com/LizardByte/Sunshine/issues/387, https://github.com/LizardByte/Sunshine/issues/412
Replaces: https://github.com/LizardByte/Sunshine/pull/485


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
